### PR TITLE
Support uploading files without making them public

### DIFF
--- a/json_schemas/options.coffee
+++ b/json_schemas/options.coffee
@@ -13,3 +13,5 @@ module.exports =
     cloudfrontHost:
       type: 'string'
       format: 'url'
+    makePublic:
+      type: 'boolean'

--- a/lib/url_s3_storer.coffee
+++ b/lib/url_s3_storer.coffee
@@ -55,9 +55,11 @@ class UrlS3Storer
       Bucket: @options.s3Bucket
       Key: @bucketKey()
       Body: streamToUpload
-      ACL: 'public-read'
       ContentLength: streamToUpload.headers['content-length']
       ContentType: streamToUpload.headers['content-type']
+
+    if !@options.hasOwnProperty('makePublic') || @options.makePublic
+      params.ACL = 'public-read'
 
     @timers.start 'upload'
 


### PR DESCRIPTION
It is a hefty assumption that the files uploaded through this should be public!
For backwards compatibility the default behaviour is still to make them public,
but can be overridden not to be.